### PR TITLE
fix: undefined startTime in request object when response event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,14 +111,21 @@ exports.plugin = {
 
                     if (!endpointPaths.includes(request.path)) {
 
-                        metric.record({
-                            startTime: request.plugins.metrics.startTime,
-                            method: request.method,
-                            path: request.route.fingerprint,
-                            /* $lab:coverage:off$ */
-                            statusCode: request.response ? request.response.statusCode : 0
-                            /* $lab:coverage:on$ */
-                        });
+                        const startTime = Hoek.reach(request, 'plugins.metrics.startTime');
+
+                        /* $lab:coverage:off$ */
+                        if (startTime) {
+                        /* $lab:coverage:on$ */
+
+                            metric.record({
+                                startTime,
+                                method: request.method,
+                                path: request.route.fingerprint,
+                                /* $lab:coverage:off$ */
+                                statusCode: request.response ? request.response.statusCode : 0
+                                /* $lab:coverage:on$ */
+                            });
+                        }
                     }
                 });
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pager/metrics-client",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pager/metrics-client",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "Hapi-centric Prometheus Plugin and optional endpoint",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Should track only valid metrics (with valid startTime) or not track them at all.