### PR TITLE
chore: update @hapi/joi to joi


### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 
 const { Registry } = require('prom-client');
 const NativeMetrics = require('@newrelic/native-metrics');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const Hoek = require('@hapi/hoek');
 
 const Pkg = require('../package.json');

--- a/lib/metrics/base.js
+++ b/lib/metrics/base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const internals = {};
 

--- a/lib/metrics/event-loop.js
+++ b/lib/metrics/event-loop.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Gauge } = require('prom-client');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const Base = require('./base');
 

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Gauge } = require('prom-client');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const Hoek = require('@hapi/hoek');
 
 const Base = require('./base');

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.0.tgz",
       "integrity": "sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -339,6 +340,7 @@
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.0.tgz",
       "integrity": "sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==",
+      "dev": true,
       "requires": {
         "@hapi/address": "^4.0.0",
         "@hapi/formula": "^2.0.0",
@@ -1290,6 +1292,28 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "joi": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.2.0.tgz",
+      "integrity": "sha512-9ZC8pMSitNlenuwKARENBGVvvGYHNlwWe5rexo2WxyogaxCB5dNHAgFA1BJQ6nsJrt/jz1p5vSqDT6W6kciDDw==",
+      "requires": {
+        "@hapi/address": "^4.1.0",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+          "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        }
+      }
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "homepage": "https://github.com/pagerinc/metrics-client#readme",
   "dependencies": {
     "@hapi/hoek": "9.x",
-    "@hapi/joi": "17.x",
     "@newrelic/native-metrics": "5.x",
+    "joi": "^17.2.0",
     "prom-client": "11.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Update the soon-to-be-deprecated @hapi/joi package to joi per https://github.com/sideway/joi/issues/2411

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖